### PR TITLE
Update Clearbar-Remediation-Script.ps1

### DIFF
--- a/Clearbar/Clearbar-Remediation-Script.ps1
+++ b/Clearbar/Clearbar-Remediation-Script.ps1
@@ -1,3 +1,4 @@
+Get-Process Clear -ErrorAction SilentlyContinue | Stop-Process -Force
 Get-Process ClearBar -ErrorAction SilentlyContinue | Stop-Process -Force
 Get-Process ClearBrowser -ErrorAction SilentlyContinue | Stop-Process -Force
 sleep 2


### PR DESCRIPTION
The main Clearbar process will continue to run after removal unless the "Clear" process is closed. 
This is unrelated, but I also found that running this script twice is sometimes needed. 🤦‍♀️